### PR TITLE
Fix `getKey` typo from PushSubscription example

### DIFF
--- a/src/_content/chapter-02/01-subscribing-a-user.md
+++ b/src/_content/chapter-02/01-subscribing-a-user.md
@@ -180,8 +180,8 @@ Once you have a push subscription you'll want to send it to your server. It's up
 const subscriptionObject = {
   endpoint: pushSubscription.endpoint,
   keys: {
-    p256dh: pushSubscription.getKeys('p256dh'),
-    auth: pushSubscription.getKeys('auth')
+    p256dh: pushSubscription.getKey('p256dh'),
+    auth: pushSubscription.getKey('auth')
   }
 };
 


### PR DESCRIPTION
Fix a typo in the Push Subscription example that demonstrates how to manually create the same result from `pushSubscription` object with `JSON.stringify` by incorrectly calling `getKeys` instead of the correct `getKey` function name from `pushSubscription` object.

## References:
- https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription/getKey
- https://web-push-book.gauntface.com/chapter-02/01-subscribing-a-user/#send-a-subscription-to-your-server